### PR TITLE
Implement RowParser composition

### DIFF
--- a/SharperAnorm/DataReaderRowParser.cs
+++ b/SharperAnorm/DataReaderRowParser.cs
@@ -76,112 +76,69 @@ namespace SharperAnorm
 
         #region Parse by column name
 
+        public static RowParser<T, IDataRecord> Named<T>(string name, Func<int, RowParser<T, IDataRecord>> byIndexParser)
+        {
+            return Safe(row => row.GetOrdinal(name)).FlatMap(byIndexParser);
+        }
+
         public static RowParser<string, IDataRecord> String(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetString(colIdx);
-            });
+            return Named(colName, String);
         }
 
         public static RowParser<int, IDataRecord> Integer(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetInt32(colIdx);
-            });
+            return Named(colName, Integer);
         }
 
         public static RowParser<long, IDataRecord> Long(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetInt64(colIdx);
-            });
+            return Named(colName, Long);
         }
 
         public static RowParser<decimal, IDataRecord> Decimal(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetDecimal(colIdx);
-            });
+            return Named(colName, Decimal);
         }
 
         public static RowParser<bool, IDataRecord> Boolean(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetBoolean(colIdx);
-            });
+            return Named(colName, Boolean);
         }
 
         public static RowParser<byte, IDataRecord> Byte(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetByte(colIdx);
-            });
+            return Named(colName, Byte);
         }
 
         public static RowParser<char, IDataRecord> Char(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetChar(colIdx);
-            });
+            return Named(colName, Char);
         }
 
         public static RowParser<short, IDataRecord> Short(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetInt16(colIdx);
-            });
+            return Named(colName, Short);
         }
 
         public static RowParser<double, IDataRecord> Double(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetDouble(colIdx);
-            });
+            return Named(colName, Double);
         }
 
         public static RowParser<float, IDataRecord> Float(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetFloat(colIdx);
-            });
+            return Named(colName, Float);
         }
 
         public static RowParser<DateTime, IDataRecord> DateTime(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetDateTime(colIdx);
-            });
+            return Named(colName, DateTime);
         }
 
         public static RowParser<object, IDataRecord> Value(string colName)
         {
-            return Safe(row =>
-            {
-                var colIdx = row.GetOrdinal(colName);
-                return row.GetValue(colIdx);
-            });
+            return Named(colName, Value);
         }
 
         #endregion

--- a/SharperAnorm/RowParser.cs
+++ b/SharperAnorm/RowParser.cs
@@ -21,6 +21,11 @@ namespace SharperAnorm
             return new RowParser<TRes, TRow>(row => Parse(row).Map(f));
         }
 
+        public RowParser<TRes, TRow> FlatMap<TRes>(Func<T, RowParser<TRes, TRow>> f)
+        {
+            return new RowParser<TRes, TRow>(row => Parse(row).FlatMap(result => f(result).Parse(row)));
+        }
+
         public RowParser<(T, TRes), TRow> And<TRes>(RowParser<TRes, TRow> otherParser)
         {
             return new RowParser<(T, TRes), TRow>(row => Parse(row).FlatMap(t => otherParser.Parse(row).Map(tr => (t, tr))));

--- a/SharperAnormTest/DataReaderRowParserTests.cs
+++ b/SharperAnormTest/DataReaderRowParserTests.cs
@@ -3,6 +3,8 @@ using System.Data;
 using Moq;
 using NUnit.Framework;
 using SharperAnorm;
+using static Moq.It;
+using Is = NUnit.Framework.Is;
 
 namespace SharperAnormTest
 {
@@ -284,9 +286,8 @@ namespace SharperAnormTest
         [Test]
         public void IndexNotFound()
         {
-            const string expected = "Test";
             var mock = new Mock<IDataRecord>();
-            mock.Setup(dr => dr.GetString(0)).Returns(expected);
+            mock.Setup(dr => dr.GetString(IsAny<int>())).Throws(new IndexOutOfRangeException());
 
             Assert.That(DataReaderRowParser.String(1).Map(t => t).Parse(mock.Object).Successful, Is.False);
         }
@@ -294,13 +295,10 @@ namespace SharperAnormTest
         [Test]
         public void ColumnNameNotFound()
         {
-            const string name = "string";
-            const string expected = "Test";
             var mock = new Mock<IDataRecord>();
-            mock.Setup(dr => dr.GetOrdinal(name)).Returns(0);
-            mock.Setup(dr => dr.GetString(0)).Returns(expected);
-
-            Assert.That(DataReaderRowParser.String("String").Map(t => t).Parse(mock.Object).Successful, Is.False);
+            mock.Setup(dr => dr.GetOrdinal(IsAny<string>())).Throws(new IndexOutOfRangeException());
+            
+            Assert.That(DataReaderRowParser.String("some_column").Parse(mock.Object).Successful, Is.False);
         }
     }
 }


### PR DESCRIPTION
This allows to reduce code duplication with the predefined name-based parsers.